### PR TITLE
feat: added private_key option, used as a docker build arg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ on:
     secrets:
       token:
         required: true
+      private_key:
+        required: false
 
 env:
   REGISTRY: ghcr.io
@@ -112,6 +114,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }},${{ matrix.image }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SSH_PRIVATE_KEY=${{ secrets.private_key }}
 
       - name: Collect Image Data
         id: collect


### PR DESCRIPTION
1. Make a key pair with NO password

```
ssh-keygen -t ed25519 -C "github-actions@github.com"
```

2. Register this key pair with your personal account **Settings > SSH and GPG keys**

3. Usage example:

```
jobs:
  deploy:
    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@ssh
    secrets:
      token: ${{ secrets.CD_TOKEN }}
      private_key: ${{ secrets.SSH_PRIVATE_KEY }}
    with:
      # Optional inputs can be passed here
      org: epfl-lasur
      repo: ws
      build_context: '["./"]'
```

where SSH_PRIVATE_KEY is defined in the private repo's **Settings > Secrets and variables > Actions** and public key was added to private repo's **Settings > Deploy keys**

Note: the key MUST be on a single line, then use `base64 -w 0` to encode it. Further usage in the Dockerfile will decode it using `base64 -d`

Dockerfile example:

```
# Install openssh-client
RUN apt-get update && apt-get install -y openssh-client git

# Add build argument for SSH key
ARG SSH_PRIVATE_KEY

# Set up SSH
RUN mkdir -p /root/.ssh && \
    echo "${SSH_PRIVATE_KEY}" | base64 -d > /root/.ssh/id_ed25519 && \
    chmod 600 /root/.ssh/id_ed25519 && \
    # Accept host keys automatically
    echo "StrictHostKeyChecking no" >> /root/.ssh/config

# Perform actions requiring private repo access
# ...
```
 
