### PR TITLE
feat(deploy): enhance multi-registry support and update documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
         required: false
         type: string
         default: '["EPFL-ENAC/enack8s-app-config"]'
+        description: 'JSON array of argo repos (legacy, used when registries is not set)'
       org:
         required: true
         type: string
@@ -31,6 +32,15 @@ on:
         required: false
         type: boolean
         default: false
+      registries:
+        required: false
+        type: string
+        default: ""
+        description: |
+          JSON array of registry configs for multi-registry push.
+          Each entry: {"registry":"ghcr.io","registry_path":"","registry_username":"","argo_repositories":["EPFL-ENAC/enack8s-app-config"]}
+          First non-ghcr registry uses registry_token secret, second uses registry_token_2.
+          If empty, falls back to single registry/registry_path/registry_username inputs.
       registry:
         required: false
         type: string
@@ -62,6 +72,8 @@ on:
         required: false
       registry_token:
         required: false
+      registry_token_2:
+        required: false
 
 env:
   CD_ORG: ${{ inputs.org }}
@@ -69,13 +81,17 @@ env:
   IMAGE_NAME: ${{ inputs.image_name }}
   CREATE_PULL_REQUEST: ${{ inputs.create_pull_request }}
 
-# proper way of doing matrix builds: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
+# Architecture: build once → push to N registries → update N manifest repos
+# Docker layers are cached via GitHub Actions cache (type=gha) so push jobs rebuild instantly from cache.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
 
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
+      push_matrix: ${{ steps.set-matrix.outputs.push_matrix }}
+      manifest_matrix: ${{ steps.set-matrix.outputs.manifest_matrix }}
     steps:
       - name: lowercase repo owner
         run: |
@@ -88,61 +104,113 @@ jobs:
           echo $IMAGE_NAME;
           echo "IMAGE_NAME=\"$IMAGE_NAME\"" >> ${GITHUB_ENV};
 
-      - name: build matrix from build_context
+      - name: Build matrices
         id: set-matrix
         shell: bash
         run: |
+          # --- Determine registries configuration ---
+          registries_input='${{ inputs.registries }}'
+          if [ -z "$registries_input" ]; then
+            # Fallback: build from legacy single-registry inputs
+            registries_json='[{"registry":"${{ inputs.registry }}","registry_path":"${{ inputs.registry_path }}","registry_username":"${{ inputs.registry_username }}","argo_repositories":${{ inputs.argo_repository }}}]'
+          else
+            registries_json="$registries_input"
+          fi
+          echo "Registries: $registries_json"
+
+          # --- Build matrix (registry-agnostic) ---
           input_json=${{ toJson(inputs.build_context) }};
-          # Transform the JSON array
-          echo "OWNER: ${{env.OWNER}}";
-          echo "IMAGE_NAME: ${{env.IMAGE_NAME}}";
-          echo $input_json;
-          output_json=$(echo "$input_json" | jq -c 'to_entries | map(
+          echo "Build contexts: $input_json";
+          build_matrix=$(echo "$input_json" | jq -c 'to_entries | map(
             (.value | rtrimstr("/")) as $ctx
             | ($ctx == "." or $ctx == "./") as $root
             | ($ctx | split("/") | .[-1]) as $leaf
             | {
-                Dockerfile: (if $root then "./Dockerfile" else ($ctx + "/Dockerfile") end),
-                context: $ctx,
+                dockerfile: (if $root then "./Dockerfile" else ($ctx + "/Dockerfile") end),
+                context: (if $root then "." else $ctx end),
                 name: (if $root then (${{ env.IMAGE_NAME }}) else $leaf end),
-                image: (if "${{ inputs.registry }}" == "ghcr.io"
-                        then ("${{ inputs.registry }}/${{ env.OWNER }}/${{ env.CD_ORG }}/" +
-                          (if $root then (${{ env.IMAGE_NAME }}) else ("${{ env.CD_REPO }}" + "/" + $leaf) end))
-                        else ("${{ inputs.registry }}/${{ inputs.registry_path }}/" +
-                          (if $root then (${{ env.IMAGE_NAME }}) else ($leaf) end))
-                        end),
                 id: (.key + 1)
               }
           )')
-          echo "matrix=$output_json" >> "$GITHUB_OUTPUT"
-          echo "$output_json"
+          echo "build_matrix=$build_matrix" >> "$GITHUB_OUTPUT"
+          echo "Build matrix: $build_matrix"
 
-      - name: Echo matrix
+          # --- Push matrix (cross-product: build contexts × registries) ---
+          owner="${{ env.OWNER }}"
+          org="${{ env.CD_ORG }}"
+          repo="${{ env.CD_REPO }}"
+          push_matrix=$(echo "$registries_json" | jq -c \
+            --argjson builds "$build_matrix" \
+            --arg owner "$owner" \
+            --arg org "$org" \
+            --arg repo "$repo" \
+            '
+            # Compute sequential index among non-ghcr registries
+            [to_entries[] | select(.value.registry != "ghcr.io")] as $non_ghcr |
+            [
+              to_entries[] | .key as $ri | .value as $reg |
+              (if $reg.registry == "ghcr.io" then 0
+               else ([$non_ghcr | to_entries[] | select(.value.key == $ri)][0].key + 1)
+               end) as $non_ghcr_idx |
+              $builds[] |
+              {
+                dockerfile: .dockerfile,
+                context: .context,
+                name: .name,
+                build_id: .id,
+                registry: $reg.registry,
+                registry_path: ($reg.registry_path // ""),
+                registry_username: ($reg.registry_username // ""),
+                non_ghcr_index: $non_ghcr_idx,
+                image: (
+                  if $reg.registry == "ghcr.io" then
+                    if .context == "." then
+                      ("ghcr.io/" + $owner + "/" + $org + "/" + .name)
+                    else
+                      ("ghcr.io/" + $owner + "/" + $org + "/" + $repo + "/" + .name)
+                    end
+                  else
+                    if (($reg.registry_path // "") | length) > 0 then
+                      ($reg.registry + "/" + $reg.registry_path + "/" + .name)
+                    else
+                      ($reg.registry + "/" + .name)
+                    end
+                  end
+                ),
+                push_id: ("r" + ($ri + 1 | tostring) + "_c" + (.id | tostring))
+              }
+            ]')
+          echo "push_matrix=$push_matrix" >> "$GITHUB_OUTPUT"
+          echo "Push matrix: $push_matrix"
+
+          # --- Manifest matrix (argo repos with their associated registry) ---
+          manifest_matrix=$(echo "$registries_json" | jq -c '[
+            to_entries[] | .value as $reg |
+            ($reg.argo_repositories // [])[] |
+            {
+              argo_repository: .,
+              registry: $reg.registry
+            }
+          ]')
+          echo "manifest_matrix=$manifest_matrix" >> "$GITHUB_OUTPUT"
+          echo "Manifest matrix: $manifest_matrix"
+
+      - name: Echo matrices
         shell: bash
-        id: echo
         run: |
-          echo ${{ steps.set-matrix.outputs.matrix }}
-  build-and-push:
+          echo "Build: ${{ steps.set-matrix.outputs.build_matrix }}"
+          echo "Push: ${{ steps.set-matrix.outputs.push_matrix }}"
+          echo "Manifest: ${{ steps.set-matrix.outputs.manifest_matrix }}"
+
+  build:
     runs-on: ubuntu-latest
     needs: define-matrix
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.define-matrix.outputs.matrix) }}
+        include: ${{ fromJson(needs.define-matrix.outputs.build_matrix) }}
     permissions:
       contents: read
-      packages: write
-    outputs:
-      image_data_1: ${{ steps.collect.outputs.image_data_1 }}
-      image_data_2: ${{ steps.collect.outputs.image_data_2 }}
-      image_data_3: ${{ steps.collect.outputs.image_data_3 }}
-      image_data_4: ${{ steps.collect.outputs.image_data_4 }}
-      image_data_5: ${{ steps.collect.outputs.image_data_5 }}
-      image_data_6: ${{ steps.collect.outputs.image_data_6 }}
-      image_data_7: ${{ steps.collect.outputs.image_data_7 }}
-      image_data_8: ${{ steps.collect.outputs.image_data_8 }}
-      image_data_9: ${{ steps.collect.outputs.image_data_9 }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -152,21 +220,70 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: GHCR registry login
-        if: ${{ inputs.registry == 'ghcr.io' }}
+      - name: Build Docker image (no push)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          load: true
+          tags: local/${{ matrix.name }}:${{ github.sha }}
+          build-args: |
+            SSH_PRIVATE_KEY=${{ secrets.private_key }}
+          cache-from: type=gha,scope=build-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}
+
+      - name: Scan image with Trivy
+        if: inputs.skip_vulnerability_scan == false
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: local/${{ matrix.name }}:${{ github.sha }}
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+
+  push:
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.define-matrix.outputs.push_matrix) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.lfs }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: matrix.registry == 'ghcr.io'
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.registry }}
-          username: ${{ inputs.registry_username }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Or custom registry login
-        if: ${{ inputs.registry != 'ghcr.io' }}
+      - name: Login to custom registry (1st)
+        if: matrix.registry != 'ghcr.io' && matrix.non_ghcr_index == 1
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.registry }}
-          username: ${{ inputs.registry_username }}
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.registry_username || github.actor }}
           password: ${{ secrets.registry_token }}
+
+      - name: Login to custom registry (2nd)
+        if: matrix.registry != 'ghcr.io' && matrix.non_ghcr_index == 2
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.registry_username || github.actor }}
+          password: ${{ secrets.registry_token_2 }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -174,100 +291,87 @@ jobs:
         with:
           images: ${{ matrix.image }}
 
-      - name: Build Docker image for security scan (no push)
-        if: inputs.skip_vulnerability_scan == false
+      - name: Build and push Docker image (from cache)
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          tags: ${{ steps.meta.outputs.tags }},${{ matrix.image }}:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-          load: true
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
-          build-args: |
-            SSH_PRIVATE_KEY=${{ secrets.private_key }}
-
-      - name: Scan image with Trivy
-        if: inputs.skip_vulnerability_scan == false
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ matrix.image }}:${{ github.sha }}
-          format: table
-          exit-code: 1
-          severity: CRITICAL,HIGH
-
-      - name: Build and push Docker image EPFL-ENAC.Agent.Service
-        id: build-docker-push
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
           push: true
-          file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }},${{ matrix.image }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          cache-from: type=gha,scope=build-${{ matrix.name }}
           build-args: |
             SSH_PRIVATE_KEY=${{ secrets.private_key }}
 
-      - name: Collect Image Data
-        id: collect
+      - name: Save image data
         run: |
-          image_data=$(jq -nc '{
+          mkdir -p /tmp/image-data
+          jq -nc '{
             "name": "${{ matrix.image }}",
-            "digest": "${{ steps.build-docker-push.outputs.digest }}",
-            "ref_name": "${{ github.ref_name }}"
-          }')
-          echo "image_data_${{ matrix.id }}=$image_data" >> $GITHUB_OUTPUT
-          echo $image_data
+            "digest": "${{ steps.push.outputs.digest }}",
+            "ref_name": "${{ github.ref_name }}",
+            "registry": "${{ matrix.registry }}",
+            "push_id": "${{ matrix.push_id }}"
+          }' > /tmp/image-data/${{ matrix.push_id }}.json
+
+      - name: Upload image data artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-data-${{ matrix.push_id }}
+          path: /tmp/image-data/${{ matrix.push_id }}.json
+          retention-days: 1
 
   update-manifest:
     runs-on: ubuntu-latest
-    needs:
-      - build-and-push
+    needs: [define-matrix, push]
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
       matrix:
-        argo_repository: ${{ fromJson(inputs.argo_repository) }}
+        include: ${{ fromJson(needs.define-matrix.outputs.manifest_matrix) }}
     steps:
-      # pretty much impossible to use multiple outputs in a matrix build
-      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs#using-job-outputs-in-a-matrix-job
-      # CF this issue on github: https://github.com/orgs/community/discussions/17245
+      - name: Download all image data
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/image-data
+          pattern: image-data-*
+          merge-multiple: true
 
-      - name: Process Images
+      - name: Process images for this registry
         id: aggregate
         run: |
-          images='${{ toJSON(needs.build-and-push.outputs) }}'
-          processed_images=$(echo "$images" | jq -r 'to_entries | map(.value | fromjson) | tostring')
-          echo "images=$processed_images" >> $GITHUB_OUTPUT
-          echo "images=$processed_images"
+          registry="${{ matrix.registry }}"
+          images=$(jq -sc "[.[] | select(.registry == \"$registry\")]" /tmp/image-data/*.json)
+          echo "images=$images" >> $GITHUB_OUTPUT
+          echo "Images for $registry: $images"
+
       - name: Set branch name
         id: set-branch
         run: |
-          if [[ "${{github.ref}}" == refs/tags/* ]]; then
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "branch=prod" >> $GITHUB_OUTPUT
             echo "branch=prod"
           fi
-          if [[ "${{github.ref}}" == refs/heads/dev ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/dev ]]; then
             echo "branch=dev" >> $GITHUB_OUTPUT
             echo "branch=dev"
           fi
-          if [[ "${{github.ref}}" == refs/heads/develop ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/develop ]]; then
             echo "branch=dev" >> $GITHUB_OUTPUT
             echo "branch=dev (src:develop => dst:dev)"
           fi
-          if [[ "${{github.ref}}" == refs/heads/test ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/test ]]; then
             echo "branch=test" >> $GITHUB_OUTPUT
             echo "branch=test"
           fi
-          if [[ "${{github.ref}}" == refs/heads/stage ]]; then
+          if [[ "${{ github.ref }}" == refs/heads/stage ]]; then
             echo "branch=stage" >> $GITHUB_OUTPUT
             echo "branch=stage"
           fi
+
       - name: Deploy application
         if: steps.set-branch.outputs.branch != ''
         run: |
@@ -286,7 +390,7 @@ jobs:
           }
           EOF
           ) && \
-          echo "Deploying application to dev" && \
+          echo "Deploying to ${{ matrix.argo_repository }}" && \
           echo "Payload: $payload" && \
           curl -X POST \
           -H "Authorization: Bearer ${{ secrets.token }}" \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,38 @@ This action implements ENAC-IT's Continuous Deployment for your app on a given e
 - if you push on the *stage* branch, same but overlay *stage*
 - if you push a tag (create a release: v1.0.0 for instance, it will update the overlay prod
 
+## Architecture
+
+The workflow is split into 4 jobs:
+
+```
+define-matrix → build → push → update-manifest
+```
+
+1. **define-matrix**: computes build contexts, registry targets, and manifest repos
+2. **build**: builds Docker images once (no push), runs vulnerability scan, caches all layers via GitHub Actions cache (`type=gha, mode=max`)
+3. **push**: rebuilds instantly from cache and pushes to each registry (matrix over registries × build contexts)
+4. **update-manifest**: downloads image metadata artifacts, dispatches to each ArgoCD manifest repo
+
+This architecture ensures each image is built only **once**, regardless of how many registries or manifest repos are configured.
+
+### Docker Build Caching
+
+Docker layers are cached using GitHub Actions cache (`cache-to: type=gha,mode=max`). The `mode=max` setting caches **all** layers including intermediate build stages, which means package installations (npm, uv, pip, etc.) are cached as Docker layers. Subsequent builds reuse cached layers when the relevant files haven't changed.
+
+For even more granular caching inside Docker builds, use BuildKit cache mounts in your Dockerfile:
+
+```dockerfile
+# npm
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+# uv
+RUN --mount=type=cache,target=/root/.cache/uv uv sync
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+```
+
 To use it in your repository, create a workflow file named `.github/workflows/deploy.yml` with the following content:
 
 
@@ -32,13 +64,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v2.7.0
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
       org: epfl-luts # your org
       repo: app-test # your app name, usual convention is name of your repository
-      argo_repository: "['EPFL-ENAC/enack8s-app-config', 'EPFL-ENAC/openshift-app-config']" # optional, default is "['EPFL-ENAC/enack8s-app-config']"
 ```
 
 Optional: override the image name when the build context is the repository root ("./" or "."). This is useful for complex repos where the default name (repo) does not match the desired image name.
@@ -49,7 +80,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v2.4.0
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
@@ -86,7 +117,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v2.4.0
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
@@ -100,6 +131,58 @@ The images pushed to the registry will be:
   - ghcr.io/epfl-enac/ethz-alice/arema/organization:{sha256}
   - ghcr.io/epfl-enac/ethz-alice/arema/projects:{sha256}
   - ghcr.io/epfl-enac/ethz-alice/arema/router:{sha256}
+
+## Multi-registry deployment
+
+To push the same images to multiple registries (e.g., ghcr.io AND a custom registry) and update different manifest repos for each:
+
+```yml
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      packages: write
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+      registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
+    with:
+      org: epfl-luts
+      repo: app-test
+      build_context: '["./backend", "./frontend"]'
+      registries: |
+        [
+          {
+            "registry": "ghcr.io",
+            "argo_repositories": ["EPFL-ENAC/enack8s-app-config"]
+          },
+          {
+            "registry": "registry.example.com",
+            "registry_path": "my-project",
+            "registry_username": "deploy-bot",
+            "argo_repositories": ["EPFL-ENAC/openshift-app-config"]
+          }
+        ]
+```
+
+This builds each image **once**, then pushes to both ghcr.io and registry.example.com, and updates separate ArgoCD manifest repos for each registry.
+
+### Registry entry format
+
+Each entry in the `registries` JSON array supports:
+
+| Field | Required | Description |
+|---|---|---|
+| `registry` | yes | Registry hostname (e.g., `ghcr.io`, `docker.io`) |
+| `registry_path` | no | Path prefix for image names (e.g., `my-project`) |
+| `registry_username` | no | Username for login (defaults to `github.actor`) |
+| `argo_repositories` | no | JSON array of ArgoCD manifest repos to update |
+
+### Registry credentials
+
+- `ghcr.io` registries use `GITHUB_TOKEN` automatically
+- The 1st non-ghcr registry uses the `registry_token` secret
+- The 2nd non-ghcr registry uses the `registry_token_2` secret
 
 ## For a repository that depends on a private repository
 
@@ -118,7 +201,7 @@ ssh-keygen -t ed25519 -C "github-actions@github.com"
 ```yml
 jobs:
   deploy:
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@ssh
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
     secrets:
       token: ${{ secrets.CD_TOKEN }}
       private_key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -166,6 +249,10 @@ RUN rm -rf /root/.ssh/
     - Default is false
   - `token`:
     The secret associated with the deployment_id - (mandatory)
+  - `registries`:
+    - JSON array of registry configurations for multi-registry push - (optional)
+    - If empty, falls back to the single `registry`/`registry_path`/`registry_username` inputs
+    - See [Multi-registry deployment](#multi-registry-deployment) for format
   - `build_context`:
     - The context of the build - (optional)
     - Currently we support max 9 contexts/ or build image per repository
@@ -218,7 +305,17 @@ RUN rm -rf /root/.ssh/
     - Has no effect on subdirectory contexts (e.g., "./modules/auth")
   - `create_pull_request`:
     - Create a pull request in the enack8s-app-config repository - (optional)
-    - Default is false, if you create a tag, it will automatically push to main without creating a PR, and deploy within the prod overlay in 5mn or so. 
+    - Default is false, if you create a tag, it will automatically push to main without creating a PR, and deploy within the prod overlay in 5mn or so.
+  - `skip_vulnerability_scan`:
+    - Skip the Trivy vulnerability scan - (optional)
+    - Default is false
+
+## Secrets
+  - `token`: PAT for dispatching to argo manifest repos - (mandatory)
+  - `private_key`: SSH private key for building from private repos - (optional)
+  - `registry_token`: Token for 1st non-ghcr registry - (optional)
+  - `registry_token_2`: Token for 2nd non-ghcr registry - (optional)
+
 ## Create one secrets in your repository
 
 Under your repository settings in /settings/secrets/actions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,239 @@
+# Workflow Architecture — v3
+
+## Problem Statement
+
+In v2, the `build-and-push` job was a single monolithic step. If a project needed to push the same image to two registries (e.g., ghcr.io and an on-prem registry) and update two different ArgoCD manifest repos, the entire workflow had to be duplicated — meaning **the same image was built twice**.
+
+### Goals
+
+1. **Build once, push many** — each Docker image is built exactly once regardless of how many registries are targeted.
+2. **Multi-registry support** — push to N registries from a single workflow invocation.
+3. **Per-registry manifest updates** — each registry can be associated with its own ArgoCD manifest repositories.
+4. **Build caching** — cache Docker layers (including package manager installs) across runs.
+5. **Backward compatibility** — existing callers using v2 inputs continue to work without changes.
+
+---
+
+## Job Pipeline
+
+```
+define-matrix → build → push → update-manifest
+```
+
+### 1. `define-matrix`
+
+Computes three matrices from inputs:
+
+| Matrix | Dimensions | Purpose |
+|---|---|---|
+| `build_matrix` | build contexts | One entry per Dockerfile/context to build |
+| `push_matrix` | build contexts × registries | Cross-product: push each image to each registry |
+| `manifest_matrix` | argo repos × registries | One entry per (argo_repository, registry) pair |
+
+**Fallback logic:** When `registries` input is empty, the job constructs a single-element registries array from the legacy `registry`, `registry_path`, `registry_username`, and `argo_repository` inputs.
+
+### 2. `build`
+
+- Matrix: `build_matrix` (one job per build context)
+- Builds each Docker image locally (`load: true`, no push)
+- Runs Trivy vulnerability scan (unless `skip_vulnerability_scan` is true)
+- Writes all layers to GitHub Actions cache (`cache-to: type=gha,mode=max`)
+- **No registry login needed** — images are never pushed here
+
+### 3. `push`
+
+- Matrix: `push_matrix` (one job per build context × registry)
+- Logs into the target registry
+- Rebuilds from GHA cache (`cache-from: type=gha`) — near-instant since all layers are cached
+- Pushes to the target registry
+- Saves image metadata (name, digest, ref_name, registry) as a GitHub Actions artifact
+
+### 4. `update-manifest`
+
+- Matrix: `manifest_matrix` (one job per argo repository)
+- Downloads all image data artifacts from the push step
+- Filters images by the registry associated with this argo repository
+- Dispatches a `repository_dispatch` event to the argo manifest repo
+
+---
+
+## Data Flow
+
+```
+                    ┌─────────────┐
+                    │define-matrix│
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │ build_matrix│push_matrix │manifest_matrix
+              ▼            ▼            ▼
+        ┌───────┐    ┌──────────┐  ┌─────────────────┐
+        │ build │    │          │  │                 │
+        │ctx: . │    │          │  │                 │
+        │ctx: A │    │          │  │                 │
+        │ctx: B │    │          │  │                 │
+        └───┬───┘    │          │  │                 │
+            │        │          │  │                 │
+     GHA cache       │          │  │                 │
+     (layers)        │          │  │                 │
+            │        ▼          │  │                 │
+            │   ┌──────────┐   │  │                 │
+            └──►│   push   │   │  │                 │
+                │ctx:. →R1 │   │  │                 │
+                │ctx:. →R2 │   │  │                 │
+                │ctx:A →R1 │   │  │                 │
+                │ctx:A →R2 │   │  │                 │
+                └────┬─────┘   │  │                 │
+                     │         │  │                 │
+              artifacts        │  │                 │
+            (image metadata)   │  │                 │
+                     │         │  ▼                 │
+                     │    ┌────┴──────────────┐     │
+                     └───►│ update-manifest   │     │
+                          │ argo-repo-1 (R1)  │     │
+                          │ argo-repo-2 (R2)  │     │
+                          └───────────────────┘     │
+```
+
+### Image metadata artifact format
+
+Each push job produces a JSON file:
+
+```json
+{
+  "name": "ghcr.io/epfl-enac/org/repo/backend",
+  "digest": "sha256:abc123...",
+  "ref_name": "dev",
+  "registry": "ghcr.io",
+  "push_id": "r1_c1"
+}
+```
+
+The `update-manifest` job downloads all artifacts and filters by `registry` to get only the images relevant to its argo repository.
+
+---
+
+## Caching Strategy
+
+### Docker Layer Cache (GHA)
+
+```yaml
+cache-from: type=gha,scope=build-${{ matrix.name }}
+cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}
+```
+
+- `mode=max` caches **all** layers, including intermediate build stages
+- This means package installs (`npm ci`, `pip install`, `uv sync`) are cached as Docker layers
+- The `build` job writes to cache; `push` jobs read from cache
+- Scoped per image name to avoid cache collisions between different images
+
+### Dockerfile-Level Cache Mounts (Optional)
+
+For even faster package installs, users can add BuildKit cache mounts in their Dockerfiles:
+
+```dockerfile
+# npm
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+# uv
+RUN --mount=type=cache,target=/root/.cache/uv uv sync
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+```
+
+These cache mounts are preserved within the GHA cache layers (`mode=max`).
+
+---
+
+## Registry Credentials
+
+| Registry type | Secret used | Condition |
+|---|---|---|
+| `ghcr.io` | `GITHUB_TOKEN` (automatic) | `matrix.registry == 'ghcr.io'` |
+| 1st non-ghcr | `registry_token` | `matrix.non_ghcr_index == 1` |
+| 2nd non-ghcr | `registry_token_2` | `matrix.non_ghcr_index == 2` |
+
+The `non_ghcr_index` is computed in `define-matrix` by `jq`, assigning a 1-based sequential index to non-ghcr registries in order.
+
+---
+
+## Backward Compatibility
+
+All v2 inputs are preserved and work as before:
+
+| v2 Input | Behavior in v3 |
+|---|---|
+| `registry` | Used when `registries` is empty |
+| `registry_path` | Used when `registries` is empty |
+| `registry_username` | Used when `registries` is empty |
+| `argo_repository` | Used when `registries` is empty (becomes `argo_repositories` in the constructed registries array) |
+| `registry_token` | Still used for the first non-ghcr registry |
+
+When `registries` is empty, `define-matrix` constructs:
+
+```json
+[{
+  "registry": "<inputs.registry>",
+  "registry_path": "<inputs.registry_path>",
+  "registry_username": "<inputs.registry_username>",
+  "argo_repositories": <inputs.argo_repository>
+}]
+```
+
+This means **no changes are needed** for existing callers.
+
+---
+
+## Usage Examples
+
+### Single registry (backward compatible)
+
+```yaml
+jobs:
+  deploy:
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+    with:
+      org: epfl-luts
+      repo: app-test
+```
+
+### Multi-registry
+
+```yaml
+jobs:
+  deploy:
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+      registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
+    with:
+      org: epfl-luts
+      repo: app-test
+      build_context: '["./backend", "./frontend"]'
+      registries: |
+        [
+          {
+            "registry": "ghcr.io",
+            "argo_repositories": ["EPFL-ENAC/enack8s-app-config"]
+          },
+          {
+            "registry": "registry.example.com",
+            "registry_path": "my-project",
+            "registry_username": "deploy-bot",
+            "argo_repositories": ["EPFL-ENAC/openshift-app-config"]
+          }
+        ]
+```
+
+This builds `backend` and `frontend` **once**, pushes both to ghcr.io and registry.example.com (4 push jobs), and triggers manifest updates on both `enack8s-app-config` (with ghcr.io images) and `openshift-app-config` (with registry.example.com images).
+
+---
+
+## Limits
+
+- Maximum 9 build contexts (unchanged from v2)
+- Maximum 2 non-ghcr registries (limited by secrets: `registry_token` and `registry_token_2`)
+- ghcr.io count is unlimited (uses `GITHUB_TOKEN`)

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -6,61 +6,48 @@ name: example_workflow
       - dev
     tags: ['v*.*.*']
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{github.repository}}
-  org: "epfl-enac"
-  repo: "my-app"
-  build_context: '["./backend", "./admin", "./frontend"]'
-  # build_context: '["."]'
-  token: "token"
+# ============================================================================
+# Example 1: Single registry (legacy mode, backward compatible)
+# ============================================================================
+# jobs:
+#   deploy:
+#     permissions:
+#       contents: read
+#       packages: write
+#     uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+#     secrets:
+#       token: ${{ secrets.CD_TOKEN }}
+#     with:
+#       org: epfl-enac
+#       repo: my-app
+#       build_context: '["./backend", "./admin", "./frontend"]'
 
-# proper way of doing matrix builds: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
-
+# ============================================================================
+# Example 2: Multi-registry (push same image to ghcr.io AND a custom registry)
+# ============================================================================
 jobs:
-  example-job:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs }}
-    steps:
-      - name: Define matrix
-        id: set-matrix
-        shell: bash
-        run: |
-          input_json=${{ toJson(env.build_context) }};
-          # Transform the JSON array
-          echo $input_json;
-          output_json=$(echo $input_json | jq -c 'to_entries | map({
-              Dockerfile: (.value + "/Dockerfile"),
-              context: .value,
-              name: (if .value != "." then .value | split("/")[1] else env.repo end),
-              image: ("ghcr.io/epfl-enac/" + env.org + "/" + (if .value != "." then .value | (env.repo + "/" +  split("/")[1]) else env.repo end)),
-              id: (.key + 1)
-          })')  
-          echo $output_json
-  all-the-output:
-      runs-on: ubuntu-latest
-      outputs:
-        image_data_1: ${{ steps.collect.outputs.image_data_1 }}
-        image_data_2: ${{ steps.collect.outputs.image_data_2 }}
-        image_data_3: ${{ steps.collect.outputs.image_data_3 }}
-        image_data_4: ${{ steps.collect.outputs.image_data_4 }}
-        image_data_5: ${{ steps.collect.outputs.image_data_5 }}
-        image_data_6: ${{ steps.collect.outputs.image_data_6 }}
-        image_data_7: ${{ steps.collect.outputs.image_data_7 }}
-        image_data_8: ${{ steps.collect.outputs.image_data_8 }}
-        image_data_9: ${{ steps.collect.outputs.image_data_9 }}
-      steps:
-        - name: Collect Image Data
-          id: collect
-          run: |
-            echo "image_data_1={}" >> $GITHUB_OUTPUT
-            echo "image_data_2={}" >> $GITHUB_OUTPUT
-            echo "image_data_3={}" >> $GITHUB_OUTPUT
-        - name: Process Images
-          id: aggregate
-          run: |
-            images='${{ toJSON(steps.collect.outputs) }}'
-            processed_images=$(echo "$images" | jq -r 'to_entries | map(.value | fromjson) | tostring')
-            echo $processed_images
-            echo $images
+  deploy:
+    permissions:
+      contents: read
+      packages: write
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+      registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
+    with:
+      org: epfl-enac
+      repo: my-app
+      build_context: '["./backend", "./frontend"]'
+      registries: |
+        [
+          {
+            "registry": "ghcr.io",
+            "argo_repositories": ["EPFL-ENAC/enack8s-app-config"]
+          },
+          {
+            "registry": "registry.example.com",
+            "registry_path": "my-project",
+            "registry_username": "deploy-bot",
+            "argo_repositories": ["EPFL-ENAC/openshift-app-config"]
+          }
+        ]


### PR DESCRIPTION
## v3: Build-once, push-many pipeline with Docker layer caching

```mermaid
flowchart LR
    A[define-matrix] --> B[build]
    B --> C[push\nregistry × context]
    C --> D[update-manifest]
```

Each image is built **once** and reused across all target registries. Docker layers are cached via GitHub Actions cache (`type=gha, mode=max`).

---

### Changes

**Architecture**
- Refactored into a 4-job pipeline: `define-matrix → build → push → update-manifest`
- `build` job builds locally (`load: true`), runs Trivy scan, and writes all layers to GHA cache
- `push` job rebuilds instantly from cache and pushes to each registry (matrix: registries × build contexts)
- Image metadata exchanged via workflow artifacts (replaces fixed `image_data_1..9` outputs)
- `update-manifest` filters images per registry before dispatching to each ArgoCD repo

**Multi-registry support**
- New `registries` JSON input for pushing to N registries from a single workflow
- Per-registry ArgoCD manifest repository configuration
- Authentication: GHCR uses `GITHUB_TOKEN`; up to 2 non-GHCR registries via `registry_token` / `registry_token_2`

**Performance**
- Docker layer caching via GHA cache with `mode=max` (caches all layers including intermediate stages)
- Package manager installs (npm, pip, uv) cached as Docker layers
- Optional BuildKit cache mounts documented for even finer-grained caching

**Backward compatibility**
- Falls back to legacy `registry`/`argo_repository` inputs when `registries` is empty
- Existing v2 callers work without changes

### Docs
- `docs/architecture.md`: full pipeline description, data flow diagram, caching strategy
- `README.md`: updated with v3 architecture overview, caching guide, multi-registry examples
- `example_workflow.yml`: single and multi-registry usage examples