### PR TITLE
feat(cache): enable GHA layer cache for image builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,9 @@ jobs:
         with:
           lfs: ${{ inputs.lfs }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: GHCR registry login
         if: ${{ inputs.registry == 'ghcr.io' }}
         uses: docker/login-action@v3
@@ -179,6 +182,9 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }},${{ matrix.image }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          load: true
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           build-args: |
             SSH_PRIVATE_KEY=${{ secrets.private_key }}
 
@@ -200,6 +206,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }},${{ matrix.image }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           build-args: |
             SSH_PRIVATE_KEY=${{ secrets.private_key }}
 


### PR DESCRIPTION
## Summary

  - Sets up `docker/setup-buildx-action@v3` so `cache-from`/`cache-to` are
  honored (the default docker driver silently ignores them).
  - Adds `cache-from: type=gha` and `cache-to: type=gha,mode=max` on **both**
  build steps (scan + push), scoped per matrix image to keep parallel builds
  from clobbering each other.
  - Adds `load: true` on the scan build so the image is loaded into the local
  docker daemon for Trivy when using the docker-container driver.

  ## Why

  Two compounding problems on every push:

  1. **No cache between runs** — every build redoes `apt-get`, source fetches,
  etc. from scratch.
  2. **v2.12.0 builds each image twice** (once for the Trivy scan, once for
  push). Without cache, the second build replays everything the first one
  already did.

  On AddLidar's `potree-converter` image this means ~6 min per build → ~12 min
  per run. With this PR, the second build hits the cache 100%, and unchanged
  Dockerfiles skip nearly all work on subsequent runs.

  ## Test plan

  - [ ] Tag `v2.13.0` and have a downstream repo (e.g. AddLidar) bump to it.
  - [ ] First run: cache miss on both builds, but second build (push) reuses
  layers from first (scan) → roughly 1x build time instead of 2x.
  - [ ] Subsequent runs with no Dockerfile change: near-instant cache hits on
  both builds.
  - [ ] Confirm Trivy still runs and can find the image (the `load: true`
  addition).

  Once it's merged and tagged v2.13.0, bump @v2.4.0 → @v2.13.0 in this repo's
  .github/workflows/deploy.yml line 15.