### PR TITLE
feat: add build_args input for custom Docker build-args

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,15 @@ on:
         required: false
         type: string
         default: false
+      build_args:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Additional Docker build-args, one KEY=VALUE per line. Appended to the
+          built-in SSH_PRIVATE_KEY arg. Useful for passing GIT_SHA, version
+          tags, etc. into the build. Unconsumed args are harmless (Docker just
+          warns).
       build_context:
         required: false
         type: string
@@ -237,6 +246,7 @@ jobs:
           tags: local/${{ matrix.name }}:${{ github.sha }}
           build-args: |
             SSH_PRIVATE_KEY=${{ secrets.private_key }}
+            ${{ inputs.build_args }}
           cache-from: type=gha,scope=build-${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}
 
@@ -311,6 +321,7 @@ jobs:
           cache-from: type=gha,scope=build-${{ matrix.name }}
           build-args: |
             SSH_PRIVATE_KEY=${{ secrets.private_key }}
+            ${{ inputs.build_args }}
 
       - name: Save image data
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to EPFL ENAC-IT Continuous Deployment Action will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] - 2026-05-08
+
+### Added
+- **Custom Docker build args** - New `build_args` input to forward extra `KEY=VALUE` pairs (one per line) to every image in the build matrix. Appended to the built-in `SSH_PRIVATE_KEY` arg; unconsumed args produce a harmless Docker warning. Typical use case: baking `GIT_SHA=${{ github.sha }}` into frontend bundles for Sentry/GlitchTip release tagging. See README for a co2-calculator example.
+
 ## [3.0.6] - 2026-05-05
 
 ### Added
@@ -150,13 +155,15 @@ Major evolution from v2.0.0 to v3.0.0 with significant new features including mu
 
 ## Migration Guide
 
-Users on v2.x can upgrade to v3.0.5 by updating the action reference:
+Users on v2.x can upgrade to v3.0.7 by updating the action reference:
 ```yaml
-uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
 ```
 
 No breaking changes - migration from v2.x to v3.0.0 is backward compatible.
 
+[3.0.7]: https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/compare/v3.0.6...v3.0.7
+[3.0.6]: https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/EPFL-ENAC/epfl-enac-build-push-deploy-action/compare/v3.0.2...v3.0.3

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
     with:
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
       registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
@@ -211,7 +211,7 @@ ssh-keygen -t ed25519 -C "github-actions@github.com"
 ```yml
 jobs:
   deploy:
-    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.5
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
     secrets:
       token: ${{ secrets.CD_TOKEN }}
       private_key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -249,6 +249,73 @@ RUN mkdir -p /root/.ssh && \
 RUN rm -rf /root/.ssh/
 ```
 
+## Passing custom Docker build args (`build_args`)
+
+Use the `build_args` input to pass extra `--build-arg KEY=VALUE` pairs into every image built by the matrix. Each line is one `KEY=VALUE`. The value is appended to the built-in `SSH_PRIVATE_KEY` arg, so both work together.
+
+A typical use case is baking the **git SHA** of the deploy into the image so frontends can report their release to error trackers (Sentry, GlitchTip), and backends can expose a `/version` endpoint.
+
+```yml
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      packages: write
+    uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3.0.7
+    secrets:
+      token: ${{ secrets.CD_TOKEN }}
+    with:
+      org: epfl
+      repo: co2-calculator
+      build_context: '[ "./frontend", "./backend", "./docs" ]'
+      build_args: |
+        GIT_SHA=${{ github.sha }}
+```
+
+The same `GIT_SHA` is forwarded to **every** Dockerfile in `build_context`. Dockerfiles that don't declare a matching `ARG` simply ignore it — Docker emits a harmless warning and the build proceeds.
+
+### Example: GlitchTip / Sentry release tagging (co2-calculator)
+
+In the **frontend** Dockerfile, accept the arg and expose it as a build-time env var so Vite/webpack inlines it into the bundle:
+
+```dockerfile
+# frontend/Dockerfile
+FROM node:22-alpine AS build
+ARG GIT_SHA=dev
+ENV VITE_APP_VERSION=$GIT_SHA
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+COPY . .
+RUN npm run build
+# ...
+```
+
+In the frontend code, initialise the Sentry/GlitchTip SDK with the SHA as the release identifier:
+
+```ts
+// frontend/src/sentry.ts
+import * as Sentry from '@sentry/vue'
+
+Sentry.init({
+  dsn: import.meta.env.VITE_GLITCHTIP_DSN,
+  release: import.meta.env.VITE_APP_VERSION, // full git SHA, baked at build time
+  environment: import.meta.env.MODE,
+})
+```
+
+Now every error event in GlitchTip is tagged with the exact deploy SHA — clicking through from an event to source takes you to the commit that produced the broken bundle.
+
+The **backend** and **docs** Dockerfiles in the same matrix don't need to consume `GIT_SHA`: passing an unused build-arg is a no-op (Docker prints `WARN: ... was not consumed`). If you do want them to expose a version endpoint, just add `ARG GIT_SHA` and use it.
+
+> Source-map upload to GlitchTip is a separate, project-local job (it requires the un-minified source maps which are not part of the runtime image). Keep using the same `${{ github.sha }}` as the release tag in that job and the events will line up.
+
+### Other use cases
+
+- `APP_VERSION=${{ github.ref_name }}` — bake a tag like `v1.2.3` into a backend response header.
+- `BUILD_DATE=${{ github.event.repository.updated_at }}` — for OCI labels.
+- `NPM_TOKEN=${{ secrets.NPM_TOKEN }}` — for private npm packages (prefer secrets/SSH keys for credentials, but the mechanism works).
+
 ## Inputs
   - `org`:
     The organization name given by ENAC-IT - (mandatory)
@@ -260,6 +327,12 @@ RUN rm -rf /root/.ssh/
   - `submodules`:
     - Enable Git submodules checkout - (optional)
     - Default is false. Can be set to true or 'recursive'
+  - `build_args`:
+    - Additional Docker build-args, one `KEY=VALUE` per line - (optional)
+    - Default is empty
+    - Appended to the built-in `SSH_PRIVATE_KEY` arg
+    - Forwarded to every image in the build matrix; unconsumed args produce a harmless Docker warning
+    - See [Passing custom Docker build args](#passing-custom-docker-build-args-build_args)
   - `token`:
     The secret associated with the deployment_id - (mandatory)
   - `registries`:

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -25,6 +25,40 @@ name: example_workflow
 # ============================================================================
 # Example 2: Multi-registry (push same image to ghcr.io AND a custom registry)
 # ============================================================================
+# jobs:
+#   deploy:
+#     permissions:
+#       contents: read
+#       packages: write
+#     uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
+#     secrets:
+#       token: ${{ secrets.CD_TOKEN }}
+#       registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
+#     with:
+#       org: epfl-enac
+#       repo: my-app
+#       build_context: '["./backend", "./frontend"]'
+#       registries: |
+#         [
+#           {
+#             "registry": "ghcr.io",
+#             "argo_repositories": ["EPFL-ENAC/enack8s-app-config"]
+#           },
+#           {
+#             "registry": "registry.example.com",
+#             "registry_path": "my-project",
+#             "registry_username": "deploy-bot",
+#             "argo_repositories": ["EPFL-ENAC/openshift-app-config"]
+#           }
+#         ]
+
+# ============================================================================
+# Example 3: Bake GIT_SHA into the build (e.g. co2-calculator + GlitchTip)
+# ============================================================================
+# Forwards GIT_SHA to every Dockerfile in build_context. Frontends can read it
+# at build time (VITE_APP_VERSION / NEXT_PUBLIC_APP_VERSION / etc.) and pass it
+# to Sentry/GlitchTip as the release identifier. Dockerfiles that don't
+# declare ARG GIT_SHA simply ignore it (Docker prints a warning, build OK).
 jobs:
   deploy:
     permissions:
@@ -33,21 +67,9 @@ jobs:
     uses: EPFL-ENAC/epfl-enac-build-push-deploy-action/.github/workflows/deploy.yml@v3
     secrets:
       token: ${{ secrets.CD_TOKEN }}
-      registry_token: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
     with:
-      org: epfl-enac
-      repo: my-app
-      build_context: '["./backend", "./frontend"]'
-      registries: |
-        [
-          {
-            "registry": "ghcr.io",
-            "argo_repositories": ["EPFL-ENAC/enack8s-app-config"]
-          },
-          {
-            "registry": "registry.example.com",
-            "registry_path": "my-project",
-            "registry_username": "deploy-bot",
-            "argo_repositories": ["EPFL-ENAC/openshift-app-config"]
-          }
-        ]
+      org: epfl
+      repo: co2-calculator
+      build_context: '[ "./frontend", "./backend", "./docs" ]'
+      build_args: |
+        GIT_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary
- New `build_args` input on the reusable `deploy.yml` workflow — forwards arbitrary `KEY=VALUE` pairs (one per line) to every image in the build matrix, appended to the built-in `SSH_PRIVATE_KEY` arg.
- Wired into both `build-push-action` invocations (no-push build + push-from-cache).
- Backwards-compatible: empty default → no behavior change for existing consumers.
- Docs: README gets a dedicated section with a co2-calculator + GlitchTip/Sentry walk-through (Dockerfile + `Sentry.init` snippet); `build_args` added to the inputs reference list. CHANGELOG entry for v3.0.7. `example_workflow.yml` gains an Example 3 for the same use case.
- Bumped all `@v3.0.5` references in docs to `@v3.0.7` (release will be cut from `main` after merge).

## Test plan
- [ ] Existing consumer (no `build_args` provided) still builds — confirms the empty-default path doesn't break anything
- [ ] co2-calculator deploy.yml updated to pass `build_args: GIT_SHA=${{ github.sha }}` and pinned to `@v3.0.7`
- [ ] Frontend Dockerfile reads `ARG GIT_SHA` and surfaces it as `VITE_APP_VERSION` (or equivalent)
- [ ] GlitchTip events on the next deploy show the full git SHA in the `release` field
- [ ] Backend/docs Dockerfiles (no `ARG GIT_SHA`) still build; check workflow logs for the harmless `WARN: ... was not consumed` line